### PR TITLE
Add Bioregistry links

### DIFF
--- a/src/main/js/components/compoundcard/ChemClassification.js
+++ b/src/main/js/components/compoundcard/ChemClassification.js
@@ -107,6 +107,11 @@ export default class ChemClassification extends React.Component {
                         </thead>
                         <tbody>
                         <tr>
+                            <!-- 
+                                // ideally, there would be associated identifiers from the ClassyFire ontology available in the `naturalProduct`
+                                // object for each of the 4 classifications that could be used to generate links via the bioregistry, 
+                                // e.g., with https://bioregistry.io/classyfire:0000001 for "Inorganic compounds"
+                            -->
                             <td style={{"whiteSpace":"nowrap",  "border":"thin solid #dee2e6"}} id={"cf1"}>{naturalProduct.chemicalTaxonomyClassyfireKingdom || "-"}</td>
                             <td style={{"whiteSpace":"nowrap",  "border":"thin solid #dee2e6"}} id={"cf2"}>{naturalProduct.chemicalTaxonomyClassyfireSuperclass || "-"}</td>
                             <td style={{"whiteSpace":"nowrap",  "border":"thin solid #dee2e6"}} id={"cf3"}>{naturalProduct.chemicalTaxonomyClassyfireClass || "-"}</td>

--- a/src/main/js/components/compoundcard/Overview.js
+++ b/src/main/js/components/compoundcard/Overview.js
@@ -39,7 +39,7 @@ export default class Overview extends React.Component {
 
         let cas_registry_num = "";
         if(naturalProduct.cas != null && naturalProduct.cas != ""){
-            cas_registry_num = <tr><td>CAS registry number</td><td>{naturalProduct.cas}</td></tr>;
+            cas_registry_num = <tr><td>CAS registry number</td><td><a href="https://bioregistry.io/cas:{naturalProduct.cas}">{naturalProduct.cas}</a></td></tr>;
         }else{
             cas_registry_num = <tr><td>CAS registry number</td><td>-</td></tr>;
         }

--- a/src/main/js/components/compoundcard/Representations.js
+++ b/src/main/js/components/compoundcard/Representations.js
@@ -31,7 +31,7 @@ export default class Representations extends React.Component {
                         <tbody>
                         <tr key={"represent_id"}>
                             <td>Temporary LOTUS id</td>
-                            <td>{naturalProduct.lotus_id}</td>
+                            <td><a href="https://bioregistry.io/lotus:{naturalProduct.lotus_id}">{naturalProduct.lotus_id}</a></td>
                         </tr>
                         <tr key={"represent_name"}>
                             <td>Name</td>

--- a/src/main/js/components/compoundcard/TaxonomyReferenceMap.js
+++ b/src/main/js/components/compoundcard/TaxonomyReferenceMap.js
@@ -165,7 +165,7 @@ export default class TaxonomyReferenceMap extends React.Component{
                             tabs_key = "NCBI";
                         }
                     }else if(db_names[j] == "GBIF Backbone Taxonomy"){
-                        organismURL = "https://www.gbif.org/species/"+tax_object.cleaned_organism_id ;
+                        organismURL = "https://bioregistry.io/gbif:" + tax_object.cleaned_organism_id ;
                         if(tabs_key == null){
                             tabs_key = "GBIF_Backbone_Taxonomy";
                         }
@@ -174,9 +174,9 @@ export default class TaxonomyReferenceMap extends React.Component{
                         if(tabs_key == null){
                             tabs_key = "iNaturalist";
                         }
-                    }/*else if(db_names[j] == "ITIS"){
-                        organismURL = ""+tax_object.cleaned_organism_id ;
-                    }*/
+                    } else if(db_names[j] == "ITIS") {
+                        organismURL = "https://bioregistry.io/itis:" + tax_object.cleaned_organism_id ;
+                    }
                     else if(db_names[j] == "Index Fungorum"){
                         organismURL = "http://www.indexfungorum.org/names/NamesRecord.asp?RecordID="+tax_object.cleaned_organism_id ;
                         if(tabs_key == null){

--- a/src/main/js/components/compoundcard/TaxonomyReferenceMap.js
+++ b/src/main/js/components/compoundcard/TaxonomyReferenceMap.js
@@ -170,7 +170,7 @@ export default class TaxonomyReferenceMap extends React.Component{
                             tabs_key = "GBIF_Backbone_Taxonomy";
                         }
                     }else if(db_names[j] == "iNaturalist"){
-                        organismURL = "https://www.inaturalist.org/taxa/"+tax_object.cleaned_organism_id ;
+                        organismURL = "https://bioregistry.io/inaturalist.taxon:" + tax_object.cleaned_organism_id ;
                         if(tabs_key == null){
                             tabs_key = "iNaturalist";
                         }
@@ -178,7 +178,7 @@ export default class TaxonomyReferenceMap extends React.Component{
                         organismURL = "https://bioregistry.io/itis:" + tax_object.cleaned_organism_id ;
                     }
                     else if(db_names[j] == "Index Fungorum"){
-                        organismURL = "http://www.indexfungorum.org/names/NamesRecord.asp?RecordID="+tax_object.cleaned_organism_id ;
+                        organismURL = "https://bioregistry.io/fungorum:" + tax_object.cleaned_organism_id ;
                         if(tabs_key == null){
                             tabs_key = "Index_Fungorum";
                         }


### PR DESCRIPTION
This PR adds Bioregistry links to each compound page for the LOTUS identifier and CAS identifier (if available). It also adds a note on how we could do the same for the ClassyFire ontology (as a follow-up to fixing its entry in the Bioregistry in https://github.com/biopragmatics/bioregistry/commit/db333e164ff7b00cec9c57b8860d0bf904fe7eb0 and https://github.com/biopragmatics/bioregistry/pull/410) if the stable identifiers were available in the `naturalProduct` for each of the 4 levels of classification